### PR TITLE
Friendship's after_destroy doesn't destroyes the two friendships

### DIFF
--- a/spec/has_friends_spec.rb
+++ b/spec/has_friends_spec.rb
@@ -116,7 +116,7 @@ describe "has_friends" do
     it "should destroy friendship" do
       expect {
         @vader.destroy_friendship_with(@luke)
-      }.should change(Friendship, :count).by(-1)
+      }.should change(Friendship, :count).by(-2)
     end
   end
 


### PR DESCRIPTION
```
  def destroy_all_friendships
    Friendship.delete_all({:user_id => id})
    Friendship.delete_all({:friend_id => id})
  end
```
